### PR TITLE
ci: use runner ubuntu-24.04

### DIFF
--- a/.github/workflows/documentation-linter.yml
+++ b/.github/workflows/documentation-linter.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   mdlint:
     name: lint markDown file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
     - uses: DavidAnson/markdownlint-cli2-action@v20


### PR DESCRIPTION
Use runner `ubuntu-24.04` explicitly instead of `ubuntu-latest`.